### PR TITLE
fixed: 引导开发者快速开始小程序

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git clone git@github.com:TencentCloudBase/tcb-game-gomoku.git tcb-game-gomoku
 
 进入「云数据库」，创建 `rooms` / `scores` / `users` 这三个集合。
 
-创建配置文件，并将其中信息替换为自己的信息：
+创建配置文件，并将其中信息替换为自己的信息(appid,appsecret,env)：
 
 ```bash
 cd tcb-game-gomoku

--- a/cloudfunctions/openid/index.js
+++ b/cloudfunctions/openid/index.js
@@ -1,10 +1,10 @@
 const querystring = require('querystring')
 const request = require('request')
 
-function getOpenID(code, secret) {
+function getOpenID(code, appid, secret) {
   const url = 'https://api.weixin.qq.com/sns/jscode2session?' +
     querystring.encode({
-      appid: 'wxe23cbe40231fcfe5',
+      appid,
       secret,
       js_code: code,
       grant_type: 'authorization_code'
@@ -35,7 +35,7 @@ function isValidStr (str) {
  * 2 传入参数错误
  */
 exports.main = async (event, context) => {
-  let { code, secret } = event
+  let { code, secret , appid } = event
   if (!isValidStr(code) || !isValidStr(secret)) {
     return {
       code: 2,
@@ -44,7 +44,7 @@ exports.main = async (event, context) => {
   }
 
   try {
-    const res = await getOpenID(code, secret)
+    const res = await getOpenID(code, appid ,secret)
     if (res.openid) {
       return {
         code: 0,

--- a/project.config.json
+++ b/project.config.json
@@ -21,7 +21,7 @@
 			"outputPath": ""
 		}
 	},
-	"appid": "wxe23cbe40231fcfe5",
+	"appid": "wx8dd675edd4c55915",
 	"projectname": "xiaochengxu-wuziqi",
 	"libVersion": "2.7.7",
 	"simulatorType": "wechat",

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 const { subscriber } = require('./shared/util.js')
-const { appSecret } = require('./config.js')
+const { appSecret , appId , env } = require('./config.js')
+
 
 //app.js
 App({
@@ -8,6 +9,7 @@ App({
       console.error('请使用 2.2.3 或以上的基础库以使用云能力')
     } else {
       wx.cloud.init({
+        env: env,
         traceUser: true,
       })
     }
@@ -30,6 +32,7 @@ App({
             name: 'openid',
             data: {
               code: res.code,
+              appid: appId,
               secret: appSecret
             }
           })

--- a/src/config.example.js
+++ b/src/config.example.js
@@ -1,4 +1,5 @@
 module.exports = {
-  appSecret: '微信公众号的appid，可以在「微信公众平台」获取',
+  appId: '开发者需要更换的自己的appid,「微信公众平台」获取',
+  appSecret: '开发者需要更换自己的appsecret,「微信公众平台」获取',
   env: '云开发环境id'
 }


### PR DESCRIPTION
其他开发者将小程序clone到本地后需要修改配置为自己的appid,appsecret，还有env在初始化没加上